### PR TITLE
Added instructions for Debian Linux 11.2

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,17 @@
+Key pre-requisites:
+
+  Perl modules:  CGI, and Compress::Zlib
+
 Simple install:
 
   % perl Makefile.PL MP_APXS=/usr/local/apache2/bin/apxs
+  % make && make test
+  % make install
+
+Simple install on Debian Linux (works with Debian 11.2):
+
+  % apt install libcgi-pm-perl libio-compress-perl libperl-dev
+  % perl Makefile.PL MP_APXS=/usr/bin/apxs
   % make && make test
   % make install
 


### PR DESCRIPTION
For users of Debian Linux 11.2 (which is the version I'm in the process of upgrading all my Debian 10 servers to), a few prerequisites are needed (for which I included some easy installation instructions) and a slightly different path to apxs.  So, I added an initial pre-requisites section that lists the Perl modules (of which I find only CGI.pm seems to be installed by default), and also added a section specifically for Debian Linux 11.2.

Hopefully this will be helpful to others who use Debian Linux, and don't want to spend as much time as I did to figure out how to get a successful compilation.